### PR TITLE
Add unit tests for login form and validation schema

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Batch",
+      "Read",
+      "Write"
+    ]
+  }
+}

--- a/frontend/src/app/login/__tests__/page.test.tsx
+++ b/frontend/src/app/login/__tests__/page.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LoginPage from '../page';
+import { LoginForm } from '@/components/login/login-form';
+
+// LoginFormコンポーネントをモック
+vi.mock('@/components/login/login-form', () => ({
+  LoginForm: vi.fn(() => <div data-testid="mocked-login-form" />),
+}));
+
+describe('LoginPage', () => {
+  it('正しくレンダリングされること', () => {
+    render(<LoginPage />);
+    
+    // ページのタイトルとサブタイトルが表示されていることを確認
+    expect(screen.getByText('nico-cal')).toBeInTheDocument();
+    expect(screen.getByText('アカウントにログイン')).toBeInTheDocument();
+    
+    // LoginFormコンポーネントがレンダリングされていることを確認
+    expect(screen.getByTestId('mocked-login-form')).toBeInTheDocument();
+  });
+
+  it('LoginFormコンポーネントが正しくレンダリングされていること', () => {
+    render(<LoginPage />);
+    
+    // LoginFormコンポーネントが呼び出されていることを確認
+    expect(LoginForm).toHaveBeenCalled();
+    
+    // ログインフォームがコンテナ内に配置されていることを確認
+    const container = screen.getByTestId('mocked-login-form').closest('div');
+    expect(container).toHaveClass('bg-white');
+    expect(container).toHaveClass('p-8');
+    expect(container).toHaveClass('rounded-lg');
+    expect(container).toHaveClass('shadow-md');
+  });
+
+  it('レスポンシブデザインのためのクラスが適用されていること', () => {
+    render(<LoginPage />);
+    
+    // ページのルートコンテナがフルスクリーンかつセンタリングされていることを確認
+    const rootContainer = screen.getByText('nico-cal').closest('div')?.parentElement;
+    expect(rootContainer).toHaveClass('min-h-screen');
+    expect(rootContainer).toHaveClass('flex');
+    expect(rootContainer).toHaveClass('flex-col');
+    expect(rootContainer).toHaveClass('items-center');
+    expect(rootContainer).toHaveClass('justify-center');
+    
+    // 内部コンテナの幅が制限されていることを確認
+    const innerContainer = screen.getByText('nico-cal').closest('div')?.parentElement;
+    expect(innerContainer).toHaveClass('w-full');
+    expect(innerContainer).toHaveClass('max-w-md');
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,27 @@
+import { Metadata } from 'next';
+import { LoginForm } from '@/components/login/login-form';
+
+export const metadata: Metadata = {
+  title: 'ログイン - nico-cal',
+  description: 'nico-calへログインしてください',
+};
+
+/**
+ * ログインページ
+ */
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold">nico-cal</h1>
+          <p className="mt-2 text-gray-600">アカウントにログイン</p>
+        </div>
+        
+        <div className="bg-white p-8 rounded-lg shadow-md">
+          <LoginForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/login/__tests__/login-form.test.tsx
+++ b/frontend/src/components/login/__tests__/login-form.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LoginForm } from '../login-form';
+import * as authSchema from '@/lib/schemas/auth';
+
+// fetchのモック
+global.fetch = vi.fn();
+
+describe('LoginForm', () => {
+  // テスト前に毎回モックをリセット
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('正しくレンダリングされること', () => {
+    render(<LoginForm />);
+    
+    // フォーム要素が存在するか確認
+    expect(screen.getByLabelText('ユーザーID')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
+  });
+
+  it('入力値が無効な場合にバリデーションエラーを表示すること', async () => {
+    render(<LoginForm />);
+    
+    // 無効なデータを入力
+    fireEvent.input(screen.getByLabelText('ユーザーID'), { target: { value: 'ab' } });
+    fireEvent.input(screen.getByLabelText('パスワード'), { target: { value: 'pass' } });
+    
+    // フォーム送信
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+    
+    // バリデーションエラーメッセージが表示されることを確認
+    await waitFor(() => {
+      expect(screen.getByText('ユーザーIDは3文字以上で入力してください')).toBeInTheDocument();
+      expect(screen.getByText('パスワードは8文字以上で入力してください')).toBeInTheDocument();
+    });
+  });
+
+  it('有効なデータでフォーム送信が成功した場合リダイレクトすること', async () => {
+    // windowのlocation.hrefをモック
+    const locationAssignMock = vi.fn();
+    delete window.location;
+    window.location = { href: '' } as any;
+    Object.defineProperty(window.location, 'href', {
+      set: locationAssignMock,
+    });
+    
+    // fetchのレスポンスをモック
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    
+    render(<LoginForm />);
+    
+    // 有効なデータを入力
+    fireEvent.input(screen.getByLabelText('ユーザーID'), { target: { value: 'testuser' } });
+    fireEvent.input(screen.getByLabelText('パスワード'), { target: { value: 'Password123' } });
+    
+    // フォーム送信
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+    
+    // APIが正しい引数で呼ばれたことを確認
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId: 'testuser',
+          password: 'Password123',
+        }),
+      });
+    });
+    
+    // リダイレクトが行われたことを確認
+    await waitFor(() => {
+      expect(locationAssignMock).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('API呼び出しが失敗した場合にエラーメッセージを表示すること', async () => {
+    // fetchのエラーレスポンスをモック
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ message: 'ユーザーIDまたはパスワードが違います' }),
+    });
+    
+    render(<LoginForm />);
+    
+    // データを入力
+    fireEvent.input(screen.getByLabelText('ユーザーID'), { target: { value: 'testuser' } });
+    fireEvent.input(screen.getByLabelText('パスワード'), { target: { value: 'Password123' } });
+    
+    // フォーム送信
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+    
+    // エラーメッセージが表示されることを確認
+    await waitFor(() => {
+      expect(screen.getByText('ユーザーIDまたはパスワードが違います')).toBeInTheDocument();
+    });
+  });
+
+  it('ネットワークエラーが発生した場合にデフォルトエラーメッセージを表示すること', async () => {
+    // fetchのエラーをモック
+    (global.fetch as any).mockRejectedValueOnce(new Error('Network Error'));
+    
+    render(<LoginForm />);
+    
+    // データを入力
+    fireEvent.input(screen.getByLabelText('ユーザーID'), { target: { value: 'testuser' } });
+    fireEvent.input(screen.getByLabelText('パスワード'), { target: { value: 'Password123' } });
+    
+    // フォーム送信
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+    
+    // デフォルトエラーメッセージが表示されることを確認
+    await waitFor(() => {
+      expect(screen.getByText('ログインに失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('送信中は入力とボタンが無効化されること', async () => {
+    // fetchのレスポンスを遅延させるモック
+    let resolvePromise: (value: any) => void;
+    const mockPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    (global.fetch as any).mockImplementationOnce(() => mockPromise);
+    
+    render(<LoginForm />);
+    
+    // データを入力
+    fireEvent.input(screen.getByLabelText('ユーザーID'), { target: { value: 'testuser' } });
+    fireEvent.input(screen.getByLabelText('パスワード'), { target: { value: 'Password123' } });
+    
+    // フォーム送信
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+    
+    // ローディング状態の確認
+    const userIdInput = screen.getByLabelText('ユーザーID');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', { name: 'ログイン中...' });
+    
+    expect(userIdInput).toBeDisabled();
+    expect(passwordInput).toBeDisabled();
+    expect(submitButton).toBeDisabled();
+    
+    // モックの解決
+    resolvePromise!({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+  });
+});

--- a/frontend/src/components/login/login-form.tsx
+++ b/frontend/src/components/login/login-form.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { loginSchema, LoginFormValues } from '@/lib/schemas/auth';
+
+/**
+ * ログインフォームコンポーネント
+ */
+export function LoginForm() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      userId: '',
+      password: '',
+    },
+  });
+
+  /**
+   * ログイン処理
+   */
+  const onSubmit = async (data: LoginFormValues) => {
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'ログインに失敗しました');
+      }
+
+      // ログイン成功時の処理
+      window.location.href = '/';
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'ログインに失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <div className="space-y-2">
+          <label htmlFor="userId" className="block text-sm font-medium">
+            ユーザーID
+          </label>
+          <input
+            id="userId"
+            type="text"
+            className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('userId')}
+            disabled={isLoading}
+          />
+          {errors.userId && (
+            <p className="text-sm text-red-500">{errors.userId.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="password" className="block text-sm font-medium">
+            パスワード
+          </label>
+          <input
+            id="password"
+            type="password"
+            className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('password')}
+            disabled={isLoading}
+          />
+          {errors.password && (
+            <p className="text-sm text-red-500">{errors.password.message}</p>
+          )}
+        </div>
+
+        {error && (
+          <div className="p-3 text-sm text-white bg-red-500 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          className="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50"
+          disabled={isLoading}
+        >
+          {isLoading ? 'ログイン中...' : 'ログイン'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/schemas/__tests__/auth.test.ts
+++ b/frontend/src/lib/schemas/__tests__/auth.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { loginSchema } from '../auth';
+
+describe('認証スキーマ', () => {
+  describe('loginSchema', () => {
+    it('有効なユーザーIDとパスワードを検証できること', () => {
+      const validInput = {
+        userId: 'testuser',
+        password: 'Password123',
+      };
+
+      const result = loginSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+    });
+
+    describe('ユーザーID検証', () => {
+      it('3文字未満のユーザーIDはエラーとなること', () => {
+        const invalidInput = {
+          userId: 'ab',
+          password: 'Password123',
+        };
+
+        const result = loginSchema.safeParse(invalidInput);
+        expect(result.success).toBe(false);
+        
+        if (!result.success) {
+          const formattedErrors = result.error.format();
+          expect(formattedErrors.userId?._errors).toContain(
+            'ユーザーIDは3文字以上で入力してください'
+          );
+        }
+      });
+
+      it('20文字を超えるユーザーIDはエラーとなること', () => {
+        const invalidInput = {
+          userId: 'a'.repeat(21),
+          password: 'Password123',
+        };
+
+        const result = loginSchema.safeParse(invalidInput);
+        expect(result.success).toBe(false);
+        
+        if (!result.success) {
+          const formattedErrors = result.error.format();
+          expect(formattedErrors.userId?._errors).toContain(
+            'ユーザーIDは20文字以下で入力してください'
+          );
+        }
+      });
+    });
+
+    describe('パスワード検証', () => {
+      it('8文字未満のパスワードはエラーとなること', () => {
+        const invalidInput = {
+          userId: 'testuser',
+          password: 'Pass1',
+        };
+
+        const result = loginSchema.safeParse(invalidInput);
+        expect(result.success).toBe(false);
+        
+        if (!result.success) {
+          const formattedErrors = result.error.format();
+          expect(formattedErrors.password?._errors).toContain(
+            'パスワードは8文字以上で入力してください'
+          );
+        }
+      });
+
+      it('英字を含まないパスワードはエラーとなること', () => {
+        const invalidInput = {
+          userId: 'testuser',
+          password: '12345678',
+        };
+
+        const result = loginSchema.safeParse(invalidInput);
+        expect(result.success).toBe(false);
+        
+        if (!result.success) {
+          const formattedErrors = result.error.format();
+          expect(formattedErrors.password?._errors).toContain(
+            'パスワードには英字を含める必要があります'
+          );
+        }
+      });
+
+      it('数字を含まないパスワードはエラーとなること', () => {
+        const invalidInput = {
+          userId: 'testuser',
+          password: 'Password',
+        };
+
+        const result = loginSchema.safeParse(invalidInput);
+        expect(result.success).toBe(false);
+        
+        if (!result.success) {
+          const formattedErrors = result.error.format();
+          expect(formattedErrors.password?._errors).toContain(
+            'パスワードには数字を含める必要があります'
+          );
+        }
+      });
+    });
+
+    it('ユーザーIDとパスワードの両方がエラーとなるケース', () => {
+      const invalidInput = {
+        userId: 'ab',
+        password: 'pass',
+      };
+
+      const result = loginSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      
+      if (!result.success) {
+        const formattedErrors = result.error.format();
+        expect(formattedErrors.userId?._errors).toContain(
+          'ユーザーIDは3文字以上で入力してください'
+        );
+        expect(formattedErrors.password?._errors).toContain(
+          'パスワードは8文字以上で入力してください'
+        );
+      }
+    });
+  });
+});

--- a/frontend/src/lib/schemas/auth.ts
+++ b/frontend/src/lib/schemas/auth.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+/**
+ * ログインフォームのバリデーションスキーマ
+ */
+export const loginSchema = z.object({
+  userId: z
+    .string()
+    .min(3, { message: 'ユーザーIDは3文字以上で入力してください' })
+    .max(20, { message: 'ユーザーIDは20文字以下で入力してください' }),
+  password: z
+    .string()
+    .min(8, { message: 'パスワードは8文字以上で入力してください' })
+    .regex(/[a-zA-Z]/, { message: 'パスワードには英字を含める必要があります' })
+    .regex(/[0-9]/, { message: 'パスワードには数字を含める必要があります' }),
+});
+
+export type LoginFormValues = z.infer<typeof loginSchema>;


### PR DESCRIPTION
## 概要
PR #22 で追加されたログインフォームと検証スキーマに対するユニットテストを追加しました。

## テスト内容
- のバリデーションテスト
- コンポーネントのレンダリング、検証、API通信のテスト
- コンポーネントのレンダリングとスタイリングのテスト

## 関連PR
- #22: Add login form with validation and styling